### PR TITLE
fix: support payable

### DIFF
--- a/src/SimulationAdapter.sol
+++ b/src/SimulationAdapter.sol
@@ -51,7 +51,7 @@ abstract contract SimulationAdapter is IERC165, ISimulationAdapter {
    * @dev This is meant to be used internally, do not call!
    * @param _call The call to simulate
    */
-  function simulateAndRevert(bytes calldata _call) external {
+  function simulateAndRevert(bytes calldata _call) external payable {
     uint256 _gasAtStart = gasleft();
     // solhint-disable-next-line avoid-low-level-calls
     (bool _success, bytes memory _result) = address(this).delegatecall(_call);

--- a/test/unit/SimulationAdapter.t.sol
+++ b/test/unit/SimulationAdapter.t.sol
@@ -31,23 +31,23 @@ contract SimulationAdapterTest is PRBTest, StdUtils {
     _calls[1] = _failedCall;
     _calls[2] = _callWithValue;
 
-    ISimulationAdapter.SimulationResult[] memory _simulationResults = myContract.simulate{value: _value}(_calls);
+    ISimulationAdapter.SimulationResult[] memory _simulationResults = myContract.simulate{ value: _value }(_calls);
 
     assertEq(_simulationResults.length, 3);
 
     // First one worked
     assertTrue(_simulationResults[0].success);
-    assertEq(_simulationResults[0].result, abi.encode(_value), 'Call 1 is different');
+    assertEq(_simulationResults[0].result, abi.encode(_value), "Call 1 is different");
     assertGt(_simulationResults[0].gasSpent, 0);
 
     // Second one failed
     assertFalse(_simulationResults[1].success);
-    assertEq(_simulationResults[1].result, abi.encodeWithSelector(Failed.selector, _value), 'Call 2 is different');
+    assertEq(_simulationResults[1].result, abi.encodeWithSelector(Failed.selector, _value), "Call 2 is different");
     assertGt(_simulationResults[1].gasSpent, 0);
 
     // Third one worked
     assertTrue(_simulationResults[2].success);
-    assertEq(_simulationResults[2].result, abi.encode(_value), 'Call 3 is different');
+    assertEq(_simulationResults[2].result, abi.encode(_value), "Call 3 is different");
     assertGt(_simulationResults[2].gasSpent, 0);
 
     // Storage was not modified any of the times

--- a/test/unit/SimulationAdapter.t.sol
+++ b/test/unit/SimulationAdapter.t.sol
@@ -21,25 +21,34 @@ contract SimulationAdapterTest is PRBTest, StdUtils {
   }
 
   function testFuzz_simulate(uint256 _value) public {
+    vm.deal(address(this), _value);
+
     bytes memory _successfulCall = abi.encodeWithSelector(myContract.modifyStorage.selector, _value);
     bytes memory _failedCall = abi.encodeWithSelector(myContract.failWithError.selector, _value);
-    bytes[] memory _calls = new bytes[](2);
+    bytes memory _callWithValue = abi.encodeWithSelector(myContract.modifyStorageWithValue.selector);
+    bytes[] memory _calls = new bytes[](3);
     _calls[0] = _successfulCall;
     _calls[1] = _failedCall;
+    _calls[2] = _callWithValue;
 
-    ISimulationAdapter.SimulationResult[] memory _simulationResults = myContract.simulate(_calls);
+    ISimulationAdapter.SimulationResult[] memory _simulationResults = myContract.simulate{value: _value}(_calls);
 
-    assertEq(_simulationResults.length, 2);
+    assertEq(_simulationResults.length, 3);
 
     // First one worked
     assertTrue(_simulationResults[0].success);
-    assertEq(_simulationResults[0].result, abi.encode(_value));
+    assertEq(_simulationResults[0].result, abi.encode(_value), 'Call 1 is different');
     assertGt(_simulationResults[0].gasSpent, 0);
 
     // Second one failed
     assertFalse(_simulationResults[1].success);
-    assertEq(_simulationResults[1].result, abi.encodeWithSelector(Failed.selector, _value));
+    assertEq(_simulationResults[1].result, abi.encodeWithSelector(Failed.selector, _value), 'Call 2 is different');
     assertGt(_simulationResults[1].gasSpent, 0);
+
+    // Third one worked
+    assertTrue(_simulationResults[2].success);
+    assertEq(_simulationResults[2].result, abi.encode(_value), 'Call 3 is different');
+    assertGt(_simulationResults[2].gasSpent, 0);
 
     // Storage was not modified any of the times
     assertEq(myContract.timesStorageModified(), 0);
@@ -51,13 +60,18 @@ error Failed(uint256 value);
 contract MyContract is SimulationAdapter {
   uint256 public timesStorageModified = 0;
 
-  function modifyStorage(uint256 _value) external returns (uint256 _returnValue) {
+  function modifyStorage(uint256 _value) external payable returns (uint256 _returnValue) {
     timesStorageModified++;
     _returnValue = _value;
   }
 
-  function failWithError(uint256 _value) external {
+  function failWithError(uint256 _value) external payable {
     timesStorageModified++;
     revert Failed(_value);
+  }
+
+  function modifyStorageWithValue() external payable returns (uint256 _returnValue) {
+    timesStorageModified++;
+    _returnValue = msg.value;
   }
 }


### PR DESCRIPTION
We realized that since `simulateAndRevert` wasn't payable, then simulations with `value` would not work.

Note: if the transaction has `msg.value`, then all calls that are simulated should also have the `payable` modifier