### PR TITLE
feat: add simulator contract

### DIFF
--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -10,8 +10,7 @@ import { ISimulator } from "./interfaces/ISimulator.sol";
  *         multicall, but the state is not modified in each subcall.
  * @dev Please note that we are using `CALL` to execute all subcalls, so the `msg.sender` WILL change
  */
-contract Simulator is ISimulator{
-
+contract Simulator is ISimulator {
   /// @notice An error that contains a simulation's result
   error SimulatedCall(SimulationResult result);
 
@@ -50,7 +49,7 @@ contract Simulator is ISimulator{
   function simulateAndRevert(Call calldata _call) external payable {
     uint256 _gasAtStart = gasleft();
     // solhint-disable-next-line avoid-low-level-calls
-    (bool _success, bytes memory _result) = _call.target.call{value: _call.value}(_call.callData);
+    (bool _success, bytes memory _result) = _call.target.call{ value: _call.value }(_call.callData);
     uint256 _gasSpent = _gasAtStart - gasleft();
     revert SimulatedCall(SimulationResult({ success: _success, result: _result, gasSpent: _gasSpent }));
   }

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+import { ISimulator } from "./interfaces/ISimulator.sol";
+
+/**
+ * @title Simulation Adapter
+ * @author Sam Bugs
+ * @notice This contracts allows to simulate calls to several contracts, all in one RPC request. It works similarly to a
+ *         multicall, but the state is not modified in each subcall.
+ * @dev Please note that we are using `CALL` to execute all subcalls, so the `msg.sender` WILL change
+ */
+contract Simulator is ISimulator{
+
+  /// @notice An error that contains a simulation's result
+  error SimulatedCall(SimulationResult result);
+
+  /// @inheritdoc ISimulator
+  function simulate(Call[] calldata _calls) external payable returns (SimulationResult[] memory _results) {
+    _results = new SimulationResult[](_calls.length);
+    for (uint256 i = 0; i < _calls.length; i++) {
+      _results[i] = _simulate(_calls[i]);
+    }
+    return _results;
+  }
+
+  /**
+   * @notice Executes a simulation and returns the result
+   * @param _call The call to simulate
+   * @return _simulationResult The simulation's result
+   */
+  function _simulate(Call calldata _call) internal returns (SimulationResult memory _simulationResult) {
+    (bool _success, bytes memory _result) =
+    // solhint-disable-next-line avoid-low-level-calls
+     address(this).delegatecall(abi.encodeWithSelector(this.simulateAndRevert.selector, _call));
+    require(!_success, "WTF? Should have failed!");
+    // Move pointer to ignore selector
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      _result := add(_result, 0x04)
+    }
+    (_simulationResult) = abi.decode(_result, (SimulationResult));
+  }
+
+  /**
+   * @notice Executes a call agains this contract and reverts with the result
+   * @dev This is meant to be used internally, do not call!
+   * @param _call The call to simulate
+   */
+  function simulateAndRevert(Call calldata _call) external payable {
+    uint256 _gasAtStart = gasleft();
+    // solhint-disable-next-line avoid-low-level-calls
+    (bool _success, bytes memory _result) = _call.target.call{value: _call.value}(_call.callData);
+    uint256 _gasSpent = _gasAtStart - gasleft();
+    revert SimulatedCall(SimulationResult({ success: _success, result: _result, gasSpent: _gasSpent }));
+  }
+}

--- a/src/interfaces/ISimulator.sol
+++ b/src/interfaces/ISimulator.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.0;
+
+interface ISimulator {
+
+  /// @notice A call to simulate
+  struct Call {
+    address target;
+    uint256 value;
+    bytes callData;
+  }
+
+  /// @notice A simulation's result
+  struct SimulationResult {
+    bool success;
+    bytes result;
+    uint256 gasSpent;
+  }
+
+  /**
+   * @notice Executes individual simulations against target contracts but doesn't modify the state when doing so
+   * @dev This function is meant to be used for off-chain simulation and should not be called on-chain
+   * @param calls The calls to simulate
+   * @return results Each simulation result
+   */
+  function simulate(Call[] calldata calls) external payable returns (SimulationResult[] memory results);
+}

--- a/src/interfaces/ISimulator.sol
+++ b/src/interfaces/ISimulator.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.0;
 
 interface ISimulator {
-
   /// @notice A call to simulate
   struct Call {
     address target;

--- a/test/unit/Simulator.t.sol
+++ b/test/unit/Simulator.t.sol
@@ -23,10 +23,10 @@ contract SimulatorTest is PRBTest, StdUtils {
     bytes memory _callWithValue = abi.encodeWithSelector(myContract.modifyStorageWithValue.selector);
     bytes memory _checkSenderCall = abi.encodeWithSelector(myContract.checkSender.selector);
     ISimulator.Call[] memory _calls = new ISimulator.Call[](4);
-    _calls[0] = ISimulator.Call({ target: address(myContract), callData: _successfulCall, value: 0});
-    _calls[1] = ISimulator.Call({ target: address(myContract), callData: _failedCall, value: 0});
-    _calls[2] = ISimulator.Call({ target: address(myContract), callData: _callWithValue, value: _value});
-    _calls[3] = ISimulator.Call({ target: address(myContract), callData: _checkSenderCall, value: 0});
+    _calls[0] = ISimulator.Call({ target: address(myContract), callData: _successfulCall, value: 0 });
+    _calls[1] = ISimulator.Call({ target: address(myContract), callData: _failedCall, value: 0 });
+    _calls[2] = ISimulator.Call({ target: address(myContract), callData: _callWithValue, value: _value });
+    _calls[3] = ISimulator.Call({ target: address(myContract), callData: _checkSenderCall, value: 0 });
 
     ISimulator.SimulationResult[] memory _simulationResults = simulator.simulate{ value: _value }(_calls);
 

--- a/test/unit/Simulator.t.sol
+++ b/test/unit/Simulator.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import { PRBTest } from "@prb/test/PRBTest.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+// solhint-disable-next-line no-unused-import
+import { Simulator, ISimulator } from "../../src/Simulator.sol";
+
+contract SimulatorTest is PRBTest, StdUtils {
+  Simulator internal simulator;
+  MyContract internal myContract;
+
+  function setUp() public virtual {
+    simulator = new Simulator();
+    myContract = new MyContract();
+  }
+
+  function testFuzz_simulate(uint256 _value) public {
+    vm.deal(address(this), _value);
+
+    bytes memory _successfulCall = abi.encodeWithSelector(myContract.modifyStorage.selector, _value);
+    bytes memory _failedCall = abi.encodeWithSelector(myContract.failWithError.selector, _value);
+    bytes memory _callWithValue = abi.encodeWithSelector(myContract.modifyStorageWithValue.selector);
+    bytes memory _checkSenderCall = abi.encodeWithSelector(myContract.checkSender.selector);
+    ISimulator.Call[] memory _calls = new ISimulator.Call[](4);
+    _calls[0] = ISimulator.Call({ target: address(myContract), callData: _successfulCall, value: 0});
+    _calls[1] = ISimulator.Call({ target: address(myContract), callData: _failedCall, value: 0});
+    _calls[2] = ISimulator.Call({ target: address(myContract), callData: _callWithValue, value: _value});
+    _calls[3] = ISimulator.Call({ target: address(myContract), callData: _checkSenderCall, value: 0});
+
+    ISimulator.SimulationResult[] memory _simulationResults = simulator.simulate{ value: _value }(_calls);
+
+    assertEq(_simulationResults.length, 4);
+
+    // First one worked
+    assertTrue(_simulationResults[0].success);
+    assertEq(_simulationResults[0].result, abi.encode(_value), "Call 1 is different");
+    assertGt(_simulationResults[0].gasSpent, 0);
+
+    // Second one failed
+    assertFalse(_simulationResults[1].success);
+    assertEq(_simulationResults[1].result, abi.encodeWithSelector(Failed.selector, _value), "Call 2 is different");
+    assertGt(_simulationResults[1].gasSpent, 0);
+
+    // Third one worked
+    assertTrue(_simulationResults[2].success);
+    assertEq(_simulationResults[2].result, abi.encode(_value), "Call 3 is different");
+    assertGt(_simulationResults[2].gasSpent, 0);
+
+    // Forth one worked
+    assertTrue(_simulationResults[3].success);
+    assertEq(_simulationResults[3].result, abi.encode(address(simulator)), "Call 4 is different");
+    assertGt(_simulationResults[3].gasSpent, 0);
+
+    // Storage was not modified any of the times
+    assertEq(myContract.timesStorageModified(), 0);
+  }
+}
+
+error Failed(uint256 value);
+
+contract MyContract {
+  uint256 public timesStorageModified = 0;
+
+  function modifyStorage(uint256 _value) external returns (uint256 _returnValue) {
+    timesStorageModified++;
+    _returnValue = _value;
+  }
+
+  function failWithError(uint256 _value) external {
+    timesStorageModified++;
+    revert Failed(_value);
+  }
+
+  function modifyStorageWithValue() external payable returns (uint256 _returnValue) {
+    timesStorageModified++;
+    _returnValue = msg.value;
+  }
+
+  function checkSender() external returns (address _returnValue) {
+    timesStorageModified++;
+    _returnValue = msg.sender;
+  }
+}


### PR DESCRIPTION
We are now adding a new singleton Simulator contract. Since existing contracts don't have the `SimulationAdapter`, we need an external contract to call them. It's important to notice that since we are performing `CALL`s, the `msg.sender` WILL change, similarly to how Multicall works